### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/421/182/275/421182275.geojson
+++ b/data/421/182/275/421182275.geojson
@@ -104,6 +104,9 @@
     },
     "wof:country":"NE",
     "wof:created":1459009324,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"caa36652610d38869d113195219977ad",
     "wof:hierarchy":[
         {
@@ -114,7 +117,7 @@
         }
     ],
     "wof:id":421182275,
-    "wof:lastmodified":1566648971,
+    "wof:lastmodified":1582355568,
     "wof:name":"Kollo",
     "wof:parent_id":85675265,
     "wof:placetype":"county",

--- a/data/421/182/277/421182277.geojson
+++ b/data/421/182/277/421182277.geojson
@@ -119,6 +119,9 @@
     },
     "wof:country":"NE",
     "wof:created":1459009324,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5d2af29b1b6609d4e84ff7af2c6bf624",
     "wof:hierarchy":[
         {
@@ -129,7 +132,7 @@
         }
     ],
     "wof:id":421182277,
-    "wof:lastmodified":1566648971,
+    "wof:lastmodified":1582355568,
     "wof:name":"Tchighozerine",
     "wof:parent_id":85675273,
     "wof:placetype":"county",

--- a/data/421/197/251/421197251.geojson
+++ b/data/421/197/251/421197251.geojson
@@ -552,6 +552,9 @@
     ],
     "wof:country":"NE",
     "wof:created":1459009907,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5f08b2d0612a13d0376c768c88cd4425",
     "wof:hierarchy":[
         {
@@ -563,7 +566,7 @@
         }
     ],
     "wof:id":421197251,
-    "wof:lastmodified":1566648971,
+    "wof:lastmodified":1582355568,
     "wof:name":"Niamey",
     "wof:parent_id":421204117,
     "wof:placetype":"locality",

--- a/data/421/204/117/421204117.geojson
+++ b/data/421/204/117/421204117.geojson
@@ -64,6 +64,9 @@
     },
     "wof:country":"NE",
     "wof:created":1459010174,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5f08b2d0612a13d0376c768c88cd4425",
     "wof:hierarchy":[
         {
@@ -74,7 +77,7 @@
         }
     ],
     "wof:id":421204117,
-    "wof:lastmodified":1537229399,
+    "wof:lastmodified":1582355567,
     "wof:name":"Niamey",
     "wof:parent_id":85675291,
     "wof:placetype":"county",

--- a/data/856/322/69/85632269.geojson
+++ b/data/856/322/69/85632269.geojson
@@ -959,6 +959,11 @@
     },
     "wof:country":"NE",
     "wof:country_alpha3":"NER",
+    "wof:geom_alt":[
+        "naturalearth",
+        "meso",
+        "naturalearth-display-terrestrial-zoom6"
+    ],
     "wof:geomhash":"a3e2f268e2c59c0142e8d1aae206742a",
     "wof:hierarchy":[
         {
@@ -973,7 +978,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1566648101,
+    "wof:lastmodified":1582355553,
     "wof:name":"Niger",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/752/65/85675265.geojson
+++ b/data/856/752/65/85675265.geojson
@@ -273,6 +273,9 @@
         "wk:page":"Tillab\u00e9ri Region"
     },
     "wof:country":"NE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cef3e2171fc415673c044febc18389ee",
     "wof:hierarchy":[
         {
@@ -288,7 +291,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1566648100,
+    "wof:lastmodified":1582355552,
     "wof:name":"Tillab\u00e9ri",
     "wof:parent_id":85632269,
     "wof:placetype":"region",

--- a/data/856/752/69/85675269.geojson
+++ b/data/856/752/69/85675269.geojson
@@ -269,6 +269,9 @@
         "wk:page":"Diffa Region"
     },
     "wof:country":"NE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6923a883383a0e6f13c291dcf386a7d9",
     "wof:hierarchy":[
         {
@@ -284,7 +287,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1566648099,
+    "wof:lastmodified":1582355551,
     "wof:name":"Diffa",
     "wof:parent_id":85632269,
     "wof:placetype":"region",

--- a/data/856/752/73/85675273.geojson
+++ b/data/856/752/73/85675273.geojson
@@ -276,6 +276,9 @@
         "wk:page":"Agadez Region"
     },
     "wof:country":"NE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c31d1bd2579bbc8d3fc3a8af60b73400",
     "wof:hierarchy":[
         {
@@ -291,7 +294,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1566648099,
+    "wof:lastmodified":1582355551,
     "wof:name":"Agadez",
     "wof:parent_id":85632269,
     "wof:placetype":"region",

--- a/data/856/752/81/85675281.geojson
+++ b/data/856/752/81/85675281.geojson
@@ -270,6 +270,9 @@
         "wk:page":"Maradi Region"
     },
     "wof:country":"NE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"f05ca5bb83d6b3b14c5574c02a48d326",
     "wof:hierarchy":[
         {
@@ -285,7 +288,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1566648099,
+    "wof:lastmodified":1582355552,
     "wof:name":"Maradi",
     "wof:parent_id":85632269,
     "wof:placetype":"region",

--- a/data/856/752/85/85675285.geojson
+++ b/data/856/752/85/85675285.geojson
@@ -270,6 +270,9 @@
         "wk:page":"Zinder Region"
     },
     "wof:country":"NE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"546d51b71b0e23df45f72782d9fb9629",
     "wof:hierarchy":[
         {
@@ -285,7 +288,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1566648100,
+    "wof:lastmodified":1582355553,
     "wof:name":"Zinder",
     "wof:parent_id":85632269,
     "wof:placetype":"region",

--- a/data/856/752/87/85675287.geojson
+++ b/data/856/752/87/85675287.geojson
@@ -273,6 +273,9 @@
         "wk:page":"Dosso Region"
     },
     "wof:country":"NE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a7afea7529da432f4af952ece4b4220d",
     "wof:hierarchy":[
         {
@@ -288,7 +291,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1566648099,
+    "wof:lastmodified":1582355552,
     "wof:name":"Dosso",
     "wof:parent_id":85632269,
     "wof:placetype":"region",

--- a/data/856/752/91/85675291.geojson
+++ b/data/856/752/91/85675291.geojson
@@ -525,6 +525,9 @@
         421197251
     ],
     "wof:country":"NE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5f08b2d0612a13d0376c768c88cd4425",
     "wof:hierarchy":[
         {
@@ -540,7 +543,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1566648100,
+    "wof:lastmodified":1582355552,
     "wof:name":"Niamey",
     "wof:parent_id":85632269,
     "wof:placetype":"region",

--- a/data/856/752/97/85675297.geojson
+++ b/data/856/752/97/85675297.geojson
@@ -267,6 +267,9 @@
         "wk:page":"Tahoua Region"
     },
     "wof:country":"NE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1a679a942c822e9196984be856c23d72",
     "wof:hierarchy":[
         {
@@ -282,7 +285,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1566648100,
+    "wof:lastmodified":1582355553,
     "wof:name":"Tahoua",
     "wof:parent_id":85632269,
     "wof:placetype":"region",

--- a/data/858/022/01/85802201.geojson
+++ b/data/858/022/01/85802201.geojson
@@ -76,6 +76,9 @@
         "qs:id":1083578
     },
     "wof:country":"NE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2e54e8a859e8f84d1ad921cc2fedd14d",
     "wof:hierarchy":[
         {
@@ -91,7 +94,7 @@
     "wof:lang":[
         "fre"
     ],
-    "wof:lastmodified":1534379385,
+    "wof:lastmodified":1582355554,
     "wof:name":"Gaw\u00e9ye",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/858/022/05/85802205.geojson
+++ b/data/858/022/05/85802205.geojson
@@ -96,6 +96,9 @@
         "qs_pg:id":894038
     },
     "wof:country":"NE",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"785ecc205df755ab842911354926c8e5",
     "wof:hierarchy":[
         {
@@ -111,7 +114,7 @@
     "wof:lang":[
         "fre"
     ],
-    "wof:lastmodified":1566648102,
+    "wof:lastmodified":1582355554,
     "wof:name":"Karadj\u00e9",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/890/418/001/890418001.geojson
+++ b/data/890/418/001/890418001.geojson
@@ -301,6 +301,9 @@
     },
     "wof:country":"NE",
     "wof:created":1469051230,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"38b8f9fc88a6710c1a37e03d468ea984",
     "wof:hierarchy":[
         {
@@ -312,7 +315,7 @@
         }
     ],
     "wof:id":890418001,
-    "wof:lastmodified":1566648972,
+    "wof:lastmodified":1582355568,
     "wof:name":"Zinder",
     "wof:parent_id":1092051411,
     "wof:placetype":"locality",

--- a/data/890/429/081/890429081.geojson
+++ b/data/890/429/081/890429081.geojson
@@ -70,6 +70,9 @@
     },
     "wof:country":"NE",
     "wof:created":1469051791,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c8227ca7ac04c9841e436845d41f2514",
     "wof:hierarchy":[
         {
@@ -80,7 +83,7 @@
         }
     ],
     "wof:id":890429081,
-    "wof:lastmodified":1566648972,
+    "wof:lastmodified":1582355568,
     "wof:name":"Tillaberi",
     "wof:parent_id":85675265,
     "wof:placetype":"county",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.