### PR TITLE
ne concordances, placetype local, and more

### DIFF
--- a/data/109/205/096/9/1092050969.geojson
+++ b/data/109/205/096/9/1092050969.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.335861,
-    "geom:area_square_m":4057581743.552462,
+    "geom:area_square_m":4057581749.23985,
     "geom:bbox":"3.175766,11.697471,3.833366,12.941371",
     "geom:latitude":12.301019,
     "geom:longitude":3.518441,
@@ -143,9 +143,10 @@
     "wof:concordances":{
         "hasc:id":"NE.DS.GA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NE",
     "wof:created":1473898548,
-    "wof:geomhash":"b3024aeec41bb76bfaf33f389fee6bb8",
+    "wof:geomhash":"7e9547006834840c2bdfb1d99ab827b2",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -155,7 +156,7 @@
         }
     ],
     "wof:id":1092050969,
-    "wof:lastmodified":1636502489,
+    "wof:lastmodified":1695886064,
     "wof:name":"Gaya",
     "wof:parent_id":85675287,
     "wof:placetype":"county",

--- a/data/109/205/100/7/1092051007.geojson
+++ b/data/109/205/100/7/1092051007.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.303884,
-    "geom:area_square_m":3657218806.695756,
+    "geom:area_square_m":3657218806.695782,
     "geom:bbox":"6.76546633973,12.9885713683,7.61376633973,13.5510713683",
     "geom:latitude":13.271759,
     "geom:longitude":7.15438,
@@ -77,9 +77,10 @@
     "wof:concordances":{
         "hasc:id":"NE.MA.MF"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NE",
     "wof:created":1473898549,
-    "wof:geomhash":"076304a804f9d55e02923e3ff03938fb",
+    "wof:geomhash":"5979014ce3a844216031ed1b3556fa2c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -89,7 +90,7 @@
         }
     ],
     "wof:id":1092051007,
-    "wof:lastmodified":1566648911,
+    "wof:lastmodified":1695886423,
     "wof:name":"Madarounfa",
     "wof:parent_id":85675281,
     "wof:placetype":"county",

--- a/data/109/205/104/1/1092051041.geojson
+++ b/data/109/205/104/1/1092051041.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.666196,
-    "geom:area_square_m":8030358044.564164,
+    "geom:area_square_m":8030358056.364438,
     "geom:bbox":"2.957366,12.106871,3.765866,13.599271",
     "geom:latitude":12.876183,
     "geom:longitude":3.278977,
@@ -98,9 +98,10 @@
     "wof:concordances":{
         "hasc:id":"NE.DS.DS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NE",
     "wof:created":1473898550,
-    "wof:geomhash":"0ff5d372b8dfe823c47a17bc803c8b2d",
+    "wof:geomhash":"b4378a58157a0909f509850a79104ac4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1092051041,
-    "wof:lastmodified":1636502489,
+    "wof:lastmodified":1695886064,
     "wof:name":"Dosso",
     "wof:parent_id":85675287,
     "wof:placetype":"county",

--- a/data/109/205/107/5/1092051075.geojson
+++ b/data/109/205/107/5/1092051075.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.374627,
-    "geom:area_square_m":4514370979.045375,
+    "geom:area_square_m":4514370985.720819,
     "geom:bbox":"2.469666,12.276771,3.109366,13.619471",
     "geom:latitude":12.954462,
     "geom:longitude":2.814694,
@@ -54,9 +54,10 @@
     "wof:concordances":{
         "hasc:id":"NE.DS.BG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NE",
     "wof:created":1473898551,
-    "wof:geomhash":"7ec8c043f0a03488fa0c88782ecd3d70",
+    "wof:geomhash":"cd1d5b6d0eebeaac498b8e1f523a79b3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -66,7 +67,7 @@
         }
     ],
     "wof:id":1092051075,
-    "wof:lastmodified":1627522463,
+    "wof:lastmodified":1695886085,
     "wof:name":"Birni N'Gaoure",
     "wof:parent_id":85675287,
     "wof:placetype":"county",

--- a/data/109/205/110/3/1092051103.geojson
+++ b/data/109/205/110/3/1092051103.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.232335,
-    "geom:area_square_m":14851189269.574432,
+    "geom:area_square_m":14851189269.574429,
     "geom:bbox":"0.990666339733,11.9015713683,2.84546633973,13.6274713683",
     "geom:latitude":12.936438,
     "geom:longitude":1.88246,
@@ -89,9 +89,10 @@
     "wof:concordances":{
         "hasc:id":"NE.TL.SA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NE",
     "wof:created":1473898552,
-    "wof:geomhash":"0415687c09b77179510564136e79fedf",
+    "wof:geomhash":"bf1da0a7187d6d725ed08f84bb0d836f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1092051103,
-    "wof:lastmodified":1566648910,
+    "wof:lastmodified":1695886423,
     "wof:name":"Say",
     "wof:parent_id":85675265,
     "wof:placetype":"county",

--- a/data/109/205/113/3/1092051133.geojson
+++ b/data/109/205/113/3/1092051133.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.667864,
-    "geom:area_square_m":8042306372.733947,
+    "geom:area_square_m":8042306372.733981,
     "geom:bbox":"8.31116633973,12.8035713683,9.87266633973,13.6314713683",
     "geom:latitude":13.130821,
     "geom:longitude":9.236112,
@@ -86,9 +86,10 @@
     "wof:concordances":{
         "hasc:id":"NE.ZI.MG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NE",
     "wof:created":1473898553,
-    "wof:geomhash":"e5309ce0e83bae6e5bdc6fdc77d43361",
+    "wof:geomhash":"1c7063c9179f26bc839bd5b1d33f6702",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":1092051133,
-    "wof:lastmodified":1566648913,
+    "wof:lastmodified":1695886424,
     "wof:name":"Magaria",
     "wof:parent_id":85675285,
     "wof:placetype":"county",

--- a/data/109/205/116/5/1092051165.geojson
+++ b/data/109/205/116/5/1092051165.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.184912,
-    "geom:area_square_m":2224141122.053527,
+    "geom:area_square_m":2224143509.55229,
     "geom:bbox":"8.255966,13.154471,8.77948,13.671875",
     "geom:latitude":13.407971,
     "geom:longitude":8.517431,
@@ -54,9 +54,10 @@
     "wof:concordances":{
         "hasc:id":"NE.ZI.MT"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NE",
     "wof:created":1473898554,
-    "wof:geomhash":"c29ca7962d43b3acea10ef8b9bf61845",
+    "wof:geomhash":"e98cf958c0f8d2fdb8191133bb25d89e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -66,7 +67,7 @@
         }
     ],
     "wof:id":1092051165,
-    "wof:lastmodified":1627522463,
+    "wof:lastmodified":1695886085,
     "wof:name":"Matamey",
     "wof:parent_id":85675285,
     "wof:placetype":"county",

--- a/data/109/205/119/7/1092051197.geojson
+++ b/data/109/205/119/7/1092051197.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.238213,
-    "geom:area_square_m":2864421312.23559,
+    "geom:area_square_m":2864421312.235581,
     "geom:bbox":"7.39036633973,13.2177713683,8.19246633973,13.7521713683",
     "geom:latitude":13.478156,
     "geom:longitude":7.750935,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"NE.MA.AG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NE",
     "wof:created":1473898555,
-    "wof:geomhash":"c0d280499da97829974ecef13d81f71b",
+    "wof:geomhash":"b22db352c9a08704ad52e05e6c6dfc13",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092051197,
-    "wof:lastmodified":1566648910,
+    "wof:lastmodified":1695886423,
     "wof:name":"Aguie",
     "wof:parent_id":85675281,
     "wof:placetype":"county",

--- a/data/109/205/122/9/1092051229.geojson
+++ b/data/109/205/122/9/1092051229.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.398987,
-    "geom:area_square_m":4794349691.491903,
+    "geom:area_square_m":4794349698.972126,
     "geom:bbox":"6.277866,13.173571,7.487466,13.907171",
     "geom:latitude":13.642445,
     "geom:longitude":6.855518,
@@ -54,9 +54,10 @@
     "wof:concordances":{
         "hasc:id":"NE.MA.GR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NE",
     "wof:created":1473898556,
-    "wof:geomhash":"0b7d44b847fbb81f0d7aa45da7a7c5f3",
+    "wof:geomhash":"36d61ba5cc63721ec76adee09902823f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -66,7 +67,7 @@
         }
     ],
     "wof:id":1092051229,
-    "wof:lastmodified":1627522463,
+    "wof:lastmodified":1695886085,
     "wof:name":"Guidan roumji",
     "wof:parent_id":85675281,
     "wof:placetype":"county",

--- a/data/109/205/124/5/1092051245.geojson
+++ b/data/109/205/124/5/1092051245.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.567726,
-    "geom:area_square_m":6824198316.943892,
+    "geom:area_square_m":6824197426.500561,
     "geom:bbox":"12.133566,13.062371,13.623291,13.915987",
     "geom:latitude":13.564398,
     "geom:longitude":12.72577,
@@ -137,9 +137,10 @@
     "wof:concordances":{
         "hasc:id":"NE.DF.DF"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NE",
     "wof:created":1473898557,
-    "wof:geomhash":"55c920cfb70234b4fbf80813469bf684",
+    "wof:geomhash":"45fd043c53603a78f4b4ac0ce3f37de4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -149,7 +150,7 @@
         }
     ],
     "wof:id":1092051245,
-    "wof:lastmodified":1636502489,
+    "wof:lastmodified":1695886064,
     "wof:name":"Diffa",
     "wof:parent_id":85675269,
     "wof:placetype":"county",

--- a/data/109/205/127/3/1092051273.geojson
+++ b/data/109/205/127/3/1092051273.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.31956,
-    "geom:area_square_m":3841167334.997699,
+    "geom:area_square_m":3841167334.997691,
     "geom:bbox":"2.99536633973,13.2492713683,3.90516633973,13.9594713683",
     "geom:latitude":13.565521,
     "geom:longitude":3.462297,
@@ -74,9 +74,10 @@
     "wof:concordances":{
         "hasc:id":"NE.DS.LO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NE",
     "wof:created":1473898559,
-    "wof:geomhash":"431c8fc177133c1ebf301aaef4b59d71",
+    "wof:geomhash":"5581bd0dd7cfd61e16c5cb4ec0a4c208",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1092051273,
-    "wof:lastmodified":1566648909,
+    "wof:lastmodified":1695886423,
     "wof:name":"Loga",
     "wof:parent_id":85675287,
     "wof:placetype":"county",

--- a/data/109/205/130/1/1092051301.geojson
+++ b/data/109/205/130/1/1092051301.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.404507,
-    "geom:area_square_m":4854065806.811876,
+    "geom:area_square_m":4854065814.568507,
     "geom:bbox":"4.445566,13.730171,5.741666,14.263271",
     "geom:latitude":13.959922,
     "geom:longitude":5.132116,
@@ -54,9 +54,10 @@
     "wof:concordances":{
         "hasc:id":"NE.TH.BK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NE",
     "wof:created":1473898559,
-    "wof:geomhash":"bf3678ae495f17e3f191a4c4ac845edc",
+    "wof:geomhash":"a385a258f32e6f74e04e5e6071f0dd5c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -66,7 +67,7 @@
         }
     ],
     "wof:id":1092051301,
-    "wof:lastmodified":1627522463,
+    "wof:lastmodified":1695886085,
     "wof:name":"Birni N'Konni",
     "wof:parent_id":85675297,
     "wof:placetype":"county",

--- a/data/109/205/132/9/1092051329.geojson
+++ b/data/109/205/132/9/1092051329.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.377295,
-    "geom:area_square_m":4526617158.652722,
+    "geom:area_square_m":4526617165.910893,
     "geom:bbox":"5.724766,13.642871,6.541766,14.363871",
     "geom:latitude":14.005613,
     "geom:longitude":6.110784,
@@ -98,9 +98,10 @@
     "wof:concordances":{
         "hasc:id":"NE.TH.MD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NE",
     "wof:created":1473898561,
-    "wof:geomhash":"3ce496424e453ec3520b35150ca068cd",
+    "wof:geomhash":"aa44a5327e951cf15b0ad11b06dcbffe",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1092051329,
-    "wof:lastmodified":1636502489,
+    "wof:lastmodified":1695886064,
     "wof:name":"Madaoua",
     "wof:parent_id":85675297,
     "wof:placetype":"county",

--- a/data/109/205/136/3/1092051363.geojson
+++ b/data/109/205/136/3/1092051363.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.290292,
-    "geom:area_square_m":15498363540.955286,
+    "geom:area_square_m":15498363565.304588,
     "geom:bbox":"10.613666,13.080871,12.448166,14.428171",
     "geom:latitude":13.733781,
     "geom:longitude":11.589476,
@@ -54,9 +54,10 @@
     "wof:concordances":{
         "hasc:id":"NE.DF.MS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NE",
     "wof:created":1473898562,
-    "wof:geomhash":"fa0f2a6922069027033b7b642c130c69",
+    "wof:geomhash":"1c911b507bbd9a022f94cebb689bfe99",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -66,7 +67,7 @@
         }
     ],
     "wof:id":1092051363,
-    "wof:lastmodified":1627522463,
+    "wof:lastmodified":1695886085,
     "wof:name":"Maine-Soroa",
     "wof:parent_id":85675269,
     "wof:placetype":"county",

--- a/data/109/205/138/9/1092051389.geojson
+++ b/data/109/205/138/9/1092051389.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.426765,
-    "geom:area_square_m":5122915167.688613,
+    "geom:area_square_m":5122915167.688446,
     "geom:bbox":"7.74076633973,13.2075713683,8.54286633973,14.4483713683",
     "geom:latitude":13.878207,
     "geom:longitude":8.188901,
@@ -92,9 +92,10 @@
     "wof:concordances":{
         "hasc:id":"NE.MA.TS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NE",
     "wof:created":1473898563,
-    "wof:geomhash":"60db5233d71ff0ab0604cd4aff8d217a",
+    "wof:geomhash":"aa85bc5cfe2f880defe3d4ac98b3e493",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1092051389,
-    "wof:lastmodified":1566648911,
+    "wof:lastmodified":1695886424,
     "wof:name":"Tessaoua",
     "wof:parent_id":85675281,
     "wof:placetype":"county",

--- a/data/109/205/141/1/1092051411.geojson
+++ b/data/109/205/141/1/1092051411.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.122076,
-    "geom:area_square_m":13468321969.96372,
+    "geom:area_square_m":13468319607.296234,
     "geom:bbox":"8.224166,13.245171,9.965666,14.508671",
     "geom:latitude":13.89833,
     "geom:longitude":9.142528,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"NE.ZI.MR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NE",
     "wof:created":1473898564,
-    "wof:geomhash":"ee6a2b4511be5e8ed8efdc27d1c1ddc2",
+    "wof:geomhash":"d9be916ac6c16c139d081023853f86fc",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1092051411,
-    "wof:lastmodified":1627522463,
+    "wof:lastmodified":1695886085,
     "wof:name":"Miria",
     "wof:parent_id":85675285,
     "wof:placetype":"county",

--- a/data/109/205/143/5/1092051435.geojson
+++ b/data/109/205/143/5/1092051435.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.543702,
-    "geom:area_square_m":6519839999.48403,
+    "geom:area_square_m":6519839999.48404,
     "geom:bbox":"7.16656633973,13.6998713683,8.08906633973,14.5167713683",
     "geom:latitude":14.119385,
     "geom:longitude":7.624592,
@@ -83,9 +83,10 @@
     "wof:concordances":{
         "hasc:id":"NE.MA.MY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NE",
     "wof:created":1473898565,
-    "wof:geomhash":"3b8df618a8fec9547c7211b567cb711b",
+    "wof:geomhash":"53689bef95f32606617eceb8c5430ee6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -95,7 +96,7 @@
         }
     ],
     "wof:id":1092051435,
-    "wof:lastmodified":1566648909,
+    "wof:lastmodified":1695886423,
     "wof:name":"Mayahi",
     "wof:parent_id":85675281,
     "wof:placetype":"county",

--- a/data/109/205/146/7/1092051467.geojson
+++ b/data/109/205/146/7/1092051467.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.926953,
-    "geom:area_square_m":11134110805.345354,
+    "geom:area_square_m":11134110805.345331,
     "geom:bbox":"3.62226633973,12.6786713683,4.59716633973,14.6354713683",
     "geom:latitude":13.729186,
     "geom:longitude":4.062298,
@@ -93,9 +93,10 @@
     "wof:concordances":{
         "hasc:id":"NE.DS.DD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NE",
     "wof:created":1473898566,
-    "wof:geomhash":"b317a9a307d120624c732b0471a3bb13",
+    "wof:geomhash":"d88c1e6b51a5ef85cbc374881d459991",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1092051467,
-    "wof:lastmodified":1566648912,
+    "wof:lastmodified":1695886424,
     "wof:name":"Dogondoutchi",
     "wof:parent_id":85675287,
     "wof:placetype":"county",

--- a/data/109/205/148/5/1092051485.geojson
+++ b/data/109/205/148/5/1092051485.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.542998,
-    "geom:area_square_m":6505186907.389392,
+    "geom:area_square_m":6505186907.389405,
     "geom:bbox":"4.20706633973,14.0197713683,5.69736633973,14.6937713683",
     "geom:latitude":14.335647,
     "geom:longitude":4.970069,
@@ -57,9 +57,10 @@
     "wof:concordances":{
         "hasc:id":"NE.TH.IL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NE",
     "wof:created":1473898567,
-    "wof:geomhash":"dccc3c0c324393ba38260dcf375b2eea",
+    "wof:geomhash":"a0976e7f4c662598f6f7b4f7714b5fe6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -69,7 +70,7 @@
         }
     ],
     "wof:id":1092051485,
-    "wof:lastmodified":1566648912,
+    "wof:lastmodified":1695886424,
     "wof:name":"Illela",
     "wof:parent_id":85675297,
     "wof:placetype":"county",

--- a/data/109/205/151/5/1092051515.geojson
+++ b/data/109/205/151/5/1092051515.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.297243,
-    "geom:area_square_m":3559347794.676263,
+    "geom:area_square_m":3559347794.676268,
     "geom:bbox":"5.64876633973,14.1807713683,6.55436633973,14.8184713683",
     "geom:latitude":14.440376,
     "geom:longitude":6.098754,
@@ -77,9 +77,10 @@
     "wof:concordances":{
         "hasc:id":"NE.TH.BZ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NE",
     "wof:created":1473898569,
-    "wof:geomhash":"ad979b725a6f92301e6534e2854d1eaa",
+    "wof:geomhash":"a23712bfe50377c956a264bd482472ec",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -89,7 +90,7 @@
         }
     ],
     "wof:id":1092051515,
-    "wof:lastmodified":1566648908,
+    "wof:lastmodified":1695886422,
     "wof:name":"Bouza",
     "wof:parent_id":85675297,
     "wof:placetype":"county",

--- a/data/109/205/154/5/1092051545.geojson
+++ b/data/109/205/154/5/1092051545.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.249757,
-    "geom:area_square_m":14981345892.601192,
+    "geom:area_square_m":14981345892.601116,
     "geom:bbox":"0.166320800781,13.3520713683,1.63086633973,14.9946899414",
     "geom:latitude":14.194196,
     "geom:longitude":0.852185,
@@ -99,9 +99,10 @@
     "wof:concordances":{
         "hasc:id":"NE.TL.TR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NE",
     "wof:created":1473898570,
-    "wof:geomhash":"daea9bf719657faff9795752a8e899b7",
+    "wof:geomhash":"847f94f383a866c92d07dcb0dafa6bee",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":1092051545,
-    "wof:lastmodified":1566648910,
+    "wof:lastmodified":1695886423,
     "wof:name":"Tera",
     "wof:parent_id":85675265,
     "wof:placetype":"county",

--- a/data/109/205/157/7/1092051577.geojson
+++ b/data/109/205/157/7/1092051577.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.416023,
-    "geom:area_square_m":4973599020.441916,
+    "geom:area_square_m":4973599020.441895,
     "geom:bbox":"5.36166633973,14.5006713683,6.55866633973,15.1102713683",
     "geom:latitude":14.796451,
     "geom:longitude":5.990422,
@@ -89,9 +89,10 @@
     "wof:concordances":{
         "hasc:id":"NE.TH.KE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NE",
     "wof:created":1473898571,
-    "wof:geomhash":"df35ec6331ab0dbf06afcf0ccc3088f8",
+    "wof:geomhash":"c252d2bbef41eb93611c826fbd6fee96",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1092051577,
-    "wof:lastmodified":1566648907,
+    "wof:lastmodified":1695886422,
     "wof:name":"Keita",
     "wof:parent_id":85675297,
     "wof:placetype":"county",

--- a/data/109/205/160/9/1092051609.geojson
+++ b/data/109/205/160/9/1092051609.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.766045,
-    "geom:area_square_m":9156185985.826941,
+    "geom:area_square_m":9156186001.425344,
     "geom:bbox":"4.120466,14.472471,5.665666,15.206771",
     "geom:latitude":14.843056,
     "geom:longitude":4.95084,
@@ -134,9 +134,10 @@
     "wof:concordances":{
         "hasc:id":"NE.TH.TH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NE",
     "wof:created":1473898572,
-    "wof:geomhash":"9bca674d2a4c36e94623619ea2cca43c",
+    "wof:geomhash":"00abba1c2f6e1ac939f6709f2ae14280",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -146,7 +147,7 @@
         }
     ],
     "wof:id":1092051609,
-    "wof:lastmodified":1636502489,
+    "wof:lastmodified":1695886064,
     "wof:name":"Tahoua",
     "wof:parent_id":85675297,
     "wof:placetype":"county",

--- a/data/109/205/163/3/1092051633.geojson
+++ b/data/109/205/163/3/1092051633.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.739074,
-    "geom:area_square_m":20800274369.189774,
+    "geom:area_square_m":20800274369.18977,
     "geom:bbox":"1.49866633973,13.8387713683,3.06496633973,15.3674926758",
     "geom:latitude":14.692842,
     "geom:longitude":2.233119,
@@ -74,9 +74,10 @@
     "wof:concordances":{
         "hasc:id":"NE.TL.OU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NE",
     "wof:created":1473898573,
-    "wof:geomhash":"02f55d24e6cdc234e01e10e83e4aec05",
+    "wof:geomhash":"91011fdff6ac87c06db5f8af825c3462",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":1092051633,
-    "wof:lastmodified":1566648911,
+    "wof:lastmodified":1695886424,
     "wof:name":"Ouallam",
     "wof:parent_id":85675265,
     "wof:placetype":"county",

--- a/data/109/205/166/3/1092051663.geojson
+++ b/data/109/205/166/3/1092051663.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.387904,
-    "geom:area_square_m":16605666897.398457,
+    "geom:area_square_m":16605666897.398388,
     "geom:bbox":"6.32856633973,13.7562713683,7.77876633973,15.4381713683",
     "geom:latitude":14.618273,
     "geom:longitude":6.988025,
@@ -77,9 +77,10 @@
     "wof:concordances":{
         "hasc:id":"NE.MA.DK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NE",
     "wof:created":1473898574,
-    "wof:geomhash":"8e6a3fc964678a96ecb47c2e1880880b",
+    "wof:geomhash":"51b6955cd69b4a7488fb8cbde7cfc8c3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -89,7 +90,7 @@
         }
     ],
     "wof:id":1092051663,
-    "wof:lastmodified":1566648907,
+    "wof:lastmodified":1695886422,
     "wof:name":"Dakoro",
     "wof:parent_id":85675281,
     "wof:placetype":"county",

--- a/data/109/205/169/5/1092051695.geojson
+++ b/data/109/205/169/5/1092051695.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.026064,
-    "geom:area_square_m":24244010069.777477,
+    "geom:area_square_m":24244010069.777519,
     "geom:bbox":"2.53306633973,13.5268713683,4.25556633973,15.6918945313",
     "geom:latitude":14.589091,
     "geom:longitude":3.402337,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"NE.TL.FI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NE",
     "wof:created":1473898575,
-    "wof:geomhash":"266e30abfce2c30ff0d3fef48465568f",
+    "wof:geomhash":"92809d392e01af87e6128d6ead2261bb",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1092051695,
-    "wof:lastmodified":1566648908,
+    "wof:lastmodified":1695886423,
     "wof:name":"Filingue",
     "wof:parent_id":85675265,
     "wof:placetype":"county",

--- a/data/109/205/173/1/1092051731.geojson
+++ b/data/109/205/173/1/1092051731.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.779398,
-    "geom:area_square_m":33184431445.450333,
+    "geom:area_square_m":33184431445.450535,
     "geom:bbox":"7.35446633973,14.1123713683,9.63006633973,16.1684713683",
     "geom:latitude":15.073412,
     "geom:longitude":8.629312,
@@ -80,9 +80,10 @@
     "wof:concordances":{
         "hasc:id":"NE.ZI.TN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NE",
     "wof:created":1473898576,
-    "wof:geomhash":"cf75fed2dfb23d9d4a4002a71d1ed188",
+    "wof:geomhash":"8cc661813a06f837de61e2014ab0ac34",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -92,7 +93,7 @@
         }
     ],
     "wof:id":1092051731,
-    "wof:lastmodified":1566648908,
+    "wof:lastmodified":1695886423,
     "wof:name":"Tanout",
     "wof:parent_id":85675285,
     "wof:placetype":"county",

--- a/data/109/205/175/3/1092051753.geojson
+++ b/data/109/205/175/3/1092051753.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":7.510745,
-    "geom:area_square_m":89556265141.357727,
+    "geom:area_square_m":89556265141.357758,
     "geom:bbox":"9.35986633973,13.0358713683,12.0027663397,17.4943713683",
     "geom:latitude":15.32362,
     "geom:longitude":10.799268,
@@ -78,9 +78,10 @@
     "wof:concordances":{
         "hasc:id":"NE.ZI.GO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NE",
     "wof:created":1473898577,
-    "wof:geomhash":"9d2dc9314554a374f06e479ebc659dbd",
+    "wof:geomhash":"d030368a25c056ddda711a23836305c1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":1092051753,
-    "wof:lastmodified":1566648910,
+    "wof:lastmodified":1695886423,
     "wof:name":"Goure",
     "wof:parent_id":85675285,
     "wof:placetype":"county",

--- a/data/109/205/178/1/1092051781.geojson
+++ b/data/109/205/178/1/1092051781.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":10.497741,
-    "geom:area_square_m":124598532639.087326,
+    "geom:area_square_m":124598540024.540024,
     "geom:bbox":"11.911966,13.770271,15.576612,18.015471",
     "geom:latitude":16.247835,
     "geom:longitude":13.448274,
@@ -54,9 +54,10 @@
     "wof:concordances":{
         "hasc:id":"NE.DF.NG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NE",
     "wof:created":1473898578,
-    "wof:geomhash":"05ba05a558239fa08ecda35dc6eaf28d",
+    "wof:geomhash":"f25864b5048f06cb91dd6850e44a4c5d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -66,7 +67,7 @@
         }
     ],
     "wof:id":1092051781,
-    "wof:lastmodified":1627522463,
+    "wof:lastmodified":1695886085,
     "wof:name":"N'Guigmi",
     "wof:parent_id":85675269,
     "wof:placetype":"county",

--- a/data/109/205/181/3/1092051813.geojson
+++ b/data/109/205/181/3/1092051813.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":6.165923,
-    "geom:area_square_m":73141848973.438766,
+    "geom:area_square_m":73141854435.697342,
     "geom:bbox":"3.855286,15.001571,6.725366,18.681519",
     "geom:latitude":16.374135,
     "geom:longitude":5.143253,
@@ -54,9 +54,10 @@
     "wof:concordances":{
         "hasc:id":"NE.TH.TC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NE",
     "wof:created":1473898579,
-    "wof:geomhash":"27ae8023562aa813fc447428751c585d",
+    "wof:geomhash":"b683464d6e366b20484d1d4bc0bd6655",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -66,7 +67,7 @@
         }
     ],
     "wof:id":1092051813,
-    "wof:lastmodified":1627522463,
+    "wof:lastmodified":1695886086,
     "wof:name":"Tchin Tabaradene",
     "wof:parent_id":85675297,
     "wof:placetype":"county",

--- a/data/109/205/184/5/1092051845.geojson
+++ b/data/109/205/184/5/1092051845.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":17.347452,
-    "geom:area_square_m":201758877394.292236,
+    "geom:area_square_m":201758877861.654083,
     "geom:bbox":"5.800766,17.904771,11.006366,22.948571",
     "geom:latitude":19.816743,
     "geom:longitude":8.873701,
@@ -125,9 +125,10 @@
     "wof:concordances":{
         "hasc:id":"NE.AG.AR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NE",
     "wof:created":1473898580,
-    "wof:geomhash":"5f6610e368f8875b1d8a7922ce4b9381",
+    "wof:geomhash":"6af8913174e292ba5ce271928714e7d7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -137,7 +138,7 @@
         }
     ],
     "wof:id":1092051845,
-    "wof:lastmodified":1636502490,
+    "wof:lastmodified":1695886064,
     "wof:name":"Arlit",
     "wof:parent_id":85675273,
     "wof:placetype":"county",

--- a/data/109/205/188/1/1092051881.geojson
+++ b/data/109/205/188/1/1092051881.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":24.035958,
-    "geom:area_square_m":278475061481.232727,
+    "geom:area_square_m":278475061481.232849,
     "geom:bbox":"10.9720663397,17.0597713683,16.0119018555,23.5250713683",
     "geom:latitude":20.395878,
     "geom:longitude":13.149444,
@@ -116,9 +116,10 @@
     "wof:concordances":{
         "hasc:id":"NE.AG.BL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NE",
     "wof:created":1473898581,
-    "wof:geomhash":"7c8b76ef5cce6681be018287cdb3f09b",
+    "wof:geomhash":"f63c6181ab6a37f13ce3c5e412bcae23",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -128,7 +129,7 @@
         }
     ],
     "wof:id":1092051881,
-    "wof:lastmodified":1566648909,
+    "wof:lastmodified":1695886423,
     "wof:name":"Bilma",
     "wof:parent_id":85675273,
     "wof:placetype":"county",

--- a/data/421/182/275/421182275.geojson
+++ b/data/421/182/275/421182275.geojson
@@ -136,7 +136,7 @@
         }
     ],
     "wof:id":421182275,
-    "wof:lastmodified":1694639689,
+    "wof:lastmodified":1695886801,
     "wof:name":"Kollo",
     "wof:parent_id":85675265,
     "wof:placetype":"county",

--- a/data/421/182/277/421182277.geojson
+++ b/data/421/182/277/421182277.geojson
@@ -151,7 +151,7 @@
         }
     ],
     "wof:id":421182277,
-    "wof:lastmodified":1694639689,
+    "wof:lastmodified":1695886801,
     "wof:name":"Tchighozerine",
     "wof:parent_id":85675273,
     "wof:placetype":"county",

--- a/data/856/322/69/85632269.geojson
+++ b/data/856/322/69/85632269.geojson
@@ -1155,6 +1155,7 @@
         "hasc:id":"NE",
         "icao:code":"5U",
         "ioc:id":"NIG",
+        "iso:code":"NE",
         "itu:id":"NGR",
         "loc:id":"n79065240",
         "m49:code":"562",
@@ -1169,6 +1170,7 @@
         "wk:page":"Niger",
         "wmo:id":"NR"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"NE",
     "wof:country_alpha3":"NER",
     "wof:geom_alt":[
@@ -1190,7 +1192,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1694639553,
+    "wof:lastmodified":1695881211,
     "wof:name":"Niger",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/752/65/85675265.geojson
+++ b/data/856/752/65/85675265.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":7.60076,
-    "geom:area_square_m":91112604305.995728,
+    "geom:area_square_m":91112620947.672501,
     "geom:bbox":"0.166321,11.901571,4.255566,15.691895",
     "geom:latitude":14.18181,
     "geom:longitude":2.187327,
@@ -269,17 +269,19 @@
         "gn:id":2595293,
         "gp:id":20069995,
         "hasc:id":"NE.TL",
+        "iso:code":"NE-6",
         "iso:id":"NE-6",
         "qs_pg:id":1118638,
         "unlc:id":"NE-6",
         "wd:id":"Q861914",
         "wk:page":"Tillab\u00e9ri Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"NE",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0649297db2af092de1539f17e3f1bb33",
+    "wof:geomhash":"20fdc6d59e7663616b8e39cf14b45287",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -294,7 +296,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690848307,
+    "wof:lastmodified":1695884366,
     "wof:name":"Tillab\u00e9ri",
     "wof:parent_id":85632269,
     "wof:placetype":"region",

--- a/data/856/752/69/85675269.geojson
+++ b/data/856/752/69/85675269.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":12.355759,
-    "geom:area_square_m":146921094496.986755,
+    "geom:area_square_m":146921101016.34549,
     "geom:bbox":"10.613666,13.062371,15.576612,18.015471",
     "geom:latitude":15.861997,
     "geom:longitude":13.220965,
@@ -274,17 +274,19 @@
         "gn:id":2445702,
         "gp:id":2346325,
         "hasc:id":"NE.DF",
+        "iso:code":"NE-2",
         "iso:id":"NE-2",
         "qs_pg:id":1135181,
         "unlc:id":"NE-2",
         "wd:id":"Q1053302",
         "wk:page":"Diffa Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"NE",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"241f403f1f416e99c3f06beffa246fae",
+    "wof:geomhash":"98396c335f357f882b1d603c88af880b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -299,7 +301,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690848306,
+    "wof:lastmodified":1695884933,
     "wof:name":"Diffa",
     "wof:parent_id":85632269,
     "wof:placetype":"region",

--- a/data/856/752/73/85675273.geojson
+++ b/data/856/752/73/85675273.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":53.685197,
-    "geom:area_square_m":625500803619.296753,
+    "geom:area_square_m":625500802109.364014,
     "geom:bbox":"4.242493,15.319471,16.011902,23.525071",
     "geom:latitude":19.484245,
     "geom:longitude":10.517389,
@@ -278,17 +278,19 @@
         "gn:id":2448083,
         "gp:id":2346324,
         "hasc:id":"NE.AG",
+        "iso:code":"NE-1",
         "iso:id":"NE-1",
         "qs_pg:id":221178,
         "unlc:id":"NE-1",
         "wd:id":"Q389944",
         "wk:page":"Agadez Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"NE",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d0c91a3ded556a29725480b77d41ea52",
+    "wof:geomhash":"9809596b0a1944ecace1e6c8c4f73b8d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -303,7 +305,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690848306,
+    "wof:lastmodified":1695884933,
     "wof:name":"Agadez",
     "wof:parent_id":85632269,
     "wof:placetype":"region",

--- a/data/856/752/81/85675281.geojson
+++ b/data/856/752/81/85675281.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.299455,
-    "geom:area_square_m":39564411874.994263,
+    "geom:area_square_m":39564411938.95298,
     "geom:bbox":"6.277866,12.988571,8.542866,15.438171",
     "geom:latitude":14.116008,
     "geom:longitude":7.302626,
@@ -275,17 +275,19 @@
         "gn:id":2441289,
         "gp:id":2346327,
         "hasc:id":"NE.MA",
+        "iso:code":"NE-4",
         "iso:id":"NE-4",
         "qs_pg:id":229380,
         "unlc:id":"NE-4",
         "wd:id":"Q850036",
         "wk:page":"Maradi Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"NE",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"20266184f486134cd7cb97b49772e025",
+    "wof:geomhash":"0132194ea2086a30318fc8c475c675cf",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -300,7 +302,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690848306,
+    "wof:lastmodified":1695884933,
     "wof:name":"Maradi",
     "wof:parent_id":85632269,
     "wof:placetype":"region",

--- a/data/856/752/85/85675285.geojson
+++ b/data/856/752/85/85675285.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":12.264994,
-    "geom:area_square_m":146475466051.559204,
+    "geom:area_square_m":146475466303.648315,
     "geom:bbox":"7.354466,12.803571,12.002766,17.494371",
     "geom:latitude":14.98824,
     "geom:longitude":10.03644,
@@ -275,17 +275,19 @@
         "gn:id":2437797,
         "gp:id":2346330,
         "hasc:id":"NE.ZI",
+        "iso:code":"NE-7",
         "iso:id":"NE-7",
         "qs_pg:id":890087,
         "unlc:id":"NE-7",
         "wd:id":"Q204367",
         "wk:page":"Zinder Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"NE",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b97a89eab94253008623f7807f235594",
+    "wof:geomhash":"d2ffd27983e7d70dd0ec4a1b3cf24aff",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -300,7 +302,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690848308,
+    "wof:lastmodified":1695884933,
     "wof:name":"Zinder",
     "wof:parent_id":85632269,
     "wof:placetype":"region",

--- a/data/856/752/87/85675287.geojson
+++ b/data/856/752/87/85675287.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.623197,
-    "geom:area_square_m":31577588907.505035,
+    "geom:area_square_m":31577588955.112263,
     "geom:bbox":"2.469666,11.697471,4.597166,14.635471",
     "geom:latitude":13.19912,
     "geom:longitude":3.542464,
@@ -281,17 +281,19 @@
         "gn:id":2445486,
         "gp:id":2346326,
         "hasc:id":"NE.DS",
+        "iso:code":"NE-3",
         "iso:id":"NE-3",
         "qs_pg:id":1222620,
         "unlc:id":"NE-3",
         "wd:id":"Q850055",
         "wk:page":"Dosso Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"NE",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"cc49bcd8fabb468e7276d7f2b87132da",
+    "wof:geomhash":"d3b8be69d6203dd97227319338355ee7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -306,7 +308,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690848306,
+    "wof:lastmodified":1695884933,
     "wof:name":"Dosso",
     "wof:parent_id":85632269,
     "wof:placetype":"region",

--- a/data/856/752/91/85675291.geojson
+++ b/data/856/752/91/85675291.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.020654,
-    "geom:area_square_m":248317207.712129,
+    "geom:area_square_m":248317208.095564,
     "geom:bbox":"2.027166,13.425171,2.233666,13.604171",
     "geom:latitude":13.511011,
     "geom:longitude":2.135139,
@@ -572,12 +572,14 @@
         "gn:id":2595294,
         "gp:id":20069994,
         "hasc:id":"NE.NI",
+        "iso:code":"NE-8",
         "iso:id":"NE-8",
         "qs_pg:id":1118637,
         "unlc:id":"NE-8",
         "wd:id":"Q3674",
         "wk:page":"Niamey"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         421197251
     ],
@@ -585,7 +587,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"09d54b39bdd3ba9d3402ac610d607399",
+    "wof:geomhash":"1298b2bfe3c2fd6924d2e7822a917ca8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -600,7 +602,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690848307,
+    "wof:lastmodified":1695884366,
     "wof:name":"Niamey",
     "wof:parent_id":85632269,
     "wof:placetype":"region",

--- a/data/856/752/97/85675297.geojson
+++ b/data/856/752/97/85675297.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":8.970034,
-    "geom:area_square_m":106716851647.23761,
+    "geom:area_square_m":106716857165.133179,
     "geom:bbox":"3.855286,13.642871,6.725366,18.681519",
     "geom:latitude":15.774236,
     "geom:longitude":5.227485,
@@ -272,17 +272,19 @@
         "gn:id":2439374,
         "gp:id":2346329,
         "hasc:id":"NE.TH",
+        "iso:code":"NE-5",
         "iso:id":"NE-5",
         "qs_pg:id":229381,
         "unlc:id":"NE-5",
         "wd:id":"Q871083",
         "wk:page":"Tahoua Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"NE",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"27d9ea7f87f439a8e6345462376d68ac",
+    "wof:geomhash":"d48982e3539de77bb05e8fc50915bbb5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -297,7 +299,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690848307,
+    "wof:lastmodified":1695884933,
     "wof:name":"Tahoua",
     "wof:parent_id":85632269,
     "wof:placetype":"region",

--- a/data/890/429/081/890429081.geojson
+++ b/data/890/429/081/890429081.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.684203,
-    "geom:area_square_m":8187521879.543653,
+    "geom:area_square_m":8187524321.218596,
     "geom:bbox":"0.707966,13.748171,1.891266,15.279294",
     "geom:latitude":14.584264,
     "geom:longitude":1.356409,
@@ -71,12 +71,13 @@
         "hasc:id":"NE.TL.TL",
         "qs_pg:id":91442
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"NE",
     "wof:created":1469051791,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"01007d97f19def2b2cd7f041881e0d31",
+    "wof:geomhash":"27ad0ba6f722f2a51bb55318ebda2e58",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -86,7 +87,7 @@
         }
     ],
     "wof:id":890429081,
-    "wof:lastmodified":1627522463,
+    "wof:lastmodified":1695886084,
     "wof:name":"Tillaberi",
     "wof:parent_id":85675265,
     "wof:placetype":"county",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.